### PR TITLE
Option to Disable Delay After Failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Optional entries:
 - `davpath` - value to override the WebDAV Path
 - `uplimit` - limit the upload speed of files (in KB/s)
 - `downlimit` - limit the download speed of files (in KB/s)
+- `usedelay` - "true" by default; use "false" to disable delay after failed runs.
 
 Note: _uplimit_ and _downlimit_ requires _nextcloudcmd_
 2.6 or newer.
@@ -239,6 +240,8 @@ delay is reached. This delay increases with subsequent failures.
 The delay starts at 1 minute, and doubles with subsequent failures,
 with the maximum delay of 24 hours. That is the delays are: 1 minute
 on the first failure, then 2, 4, 8 minutes etc.
+
+If `usedelay` is set to `false` in the config, the delay is held at 1 second in all cases, effectively disabling it.
 
 
 # Exit status

--- a/nextcloud-sync-cron.sh
+++ b/nextcloud-sync-cron.sh
@@ -218,6 +218,7 @@ DOWNLIMIT=`getconfig --optional downlimit "$CONF_FILE"`
 EXCLUDE=`getconfig --optional exclude "$CONF_FILE"`
 HTTPPROXY=`getconfig --optional httpproxy "$CONF_FILE"`
 TRUST=`getconfig --optional trust "$CONF_FILE"`
+USEDELAY=`getconfig --optional usedelay "$CONF_FILE"`
 
 # Mandatory config options
 
@@ -368,12 +369,22 @@ if [ -e "$BAD_FILE" ]; then
 
     # Determine delay before retrying
     # Current algorithm: 1, 2, 4 minute ... 4, 8, 16, 24, 24, 24 hours ...
+     
+    if [ -n "$USEDELAY" -a "$USEDELAY" != 'true' ]; then
+        USEDELAY="false"
+    else
+        USEDELAY="true"
+    fi
+    
+    if [ "$USEDELAY" == 'true' ]; then
+        MAX_DELAY=$((60 * 60 * 24))  # 1 day
 
-    MAX_DELAY=$((60 * 60 * 24))  # 1 day
-
-    DELAY=$(( 2 ** (($NUM_FAILURES - 1)) * 60 ))
-    if [ $DELAY -gt $MAX_DELAY ]; then
-	DELAY=$MAX_DELAY
+        DELAY=$(( 2 ** (($NUM_FAILURES - 1)) * 60 ))
+        if [ $DELAY -gt $MAX_DELAY ]; then
+            DELAY=$MAX_DELAY
+        fi
+    else
+        DELAY=1  # 1 second
     fi
 
     # Abort if reason was configuration error and it has not been fixed


### PR DESCRIPTION
So, I added (and documented) a `usedelay` option, which when set to 'false' will entirely turn off the delay.

The script's behavior remains unchanged, unless `usedelay` is explicitly specified to be `false`.

## Why?

Subjectively, I didn't like the the default delay behavior - just 32 minutes without wifi means that sync won't be attempted for over an hour, when running the script once a minute through cron.

Some others undoubtedly feel as I do, but it's a really subjective thing. Therefore, I figured that a configuration option that doesn't change any default behavior was an appropriate way to share these feelings :).