### PR TITLE
Make shebang compatible with other distros

### DIFF
--- a/nextcloud-sync-cron.sh
+++ b/nextcloud-sync-cron.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Nextcloud sync cron script.
 #


### PR DESCRIPTION
This is necessary for the script to run on Guix OS for example.